### PR TITLE
Fix hex color parsing in color utility

### DIFF
--- a/content/color-utils.js
+++ b/content/color-utils.js
@@ -1,20 +1,23 @@
 function parseColor(color) {
-    if (color.startsWith('#')) {
-      const hex = color.slice(1);
-      return [
-        parseInt(hex.slice(0, 2), 
-        parseInt(hex.slice(2, 4),
-        parseInt(hex.slice(4, 6))
-      ].map(v => v / 255);
-    }
-    
-    if (color.startsWith('rgb')) {
-      return color.match(/\d+/g).map(Number).slice(0, 3)
-        .map(v => v / 255);
-    }
-    
-    return [0, 0, 0]; // Fallback
+  if (color.startsWith('#')) {
+    const hex = color.slice(1);
+    return [
+      parseInt(hex.slice(0, 2), 16),
+      parseInt(hex.slice(2, 4), 16),
+      parseInt(hex.slice(4, 6), 16)
+    ].map((v) => v / 255);
   }
+
+  if (color.startsWith('rgb')) {
+    return color
+      .match(/\d+/g)
+      .map(Number)
+      .slice(0, 3)
+      .map((v) => v / 255);
+  }
+
+  return [0, 0, 0]; // Fallback
+}
   
   function getLuminance(rgb) {
     const [r, g, b] = rgb.map(v => 


### PR DESCRIPTION
## Summary
- correct hex color parsing in color-utils by providing radix and closing parentheses
- improve color utility formatting

## Testing
- `node --experimental-modules -e "import('file:///workspace/fontsdetects/content/color-utils.js').then(m=>console.log('ratio',m.getContrastRatio('#000000','#ffffff'))).catch(err=>console.error(err))"`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689911739ef8832a9fbba188cbe5bd39